### PR TITLE
Metallicity PDF adding

### DIFF
--- a/docs/metallicity.rst
+++ b/docs/metallicity.rst
@@ -57,9 +57,11 @@ One can calculate the bounds of a confidence interval with::
 
    mpdf.confidence_limits(0.68)
 
-One can combine two MetallicityPDF's with math::
+One can combine two MetallicityPDF's with math.  The resultant PDF is
+**not** normalized.::
 
    sum_pdf = mpdf + mpdf2
+   sum_pdf.normalize()
 
 Plots
 -----

--- a/pyigm/metallicity/pdf.py
+++ b/pyigm/metallicity/pdf.py
@@ -2,8 +2,11 @@
 """
 from __future__ import print_function, absolute_import, division, unicode_literals
 
+import warnings
+
 import numpy as np
 from scipy.interpolate import interp1d
+
 
 import pdb
 
@@ -19,7 +22,7 @@ class MetallicityPDF(object):
       PDF of the metallicity
     """
 
-    def __init__(self, ZH, pdf_ZH, parent=None, dZH=None):
+    def __init__(self, ZH, pdf_ZH, parent=None, dZH=None, normalize=True):
         """
         Parameters
         ----------
@@ -29,8 +32,10 @@ class MetallicityPDF(object):
           PDF of the metallicity
         parent : object, optional
           Parent of the metalliicty PDF, e.g. an AbsSystem
-        dZH : float or ndarray
+        dZH : float or ndarray, optional
           Width of the ZH 'bins' (log 10)
+        normalize : bool, optional
+          Normalize the input PDF?
 
         Returns
         -------
@@ -54,7 +59,10 @@ class MetallicityPDF(object):
             self.dZH = dZH
 
         # Normalize pdf_ZH
-        self.normalize()
+        if normalize:
+            self.normalize()
+        else:
+            warnings.warn("Not normalizing the PDF")
 
     @property
     def meanZH(self):
@@ -168,13 +176,14 @@ class MetallicityPDF(object):
         Returns
         -------
         MetallicityPDF
+          The
 
         """
         # Check that the ZH arrays are identical
         if not np.allclose(self.ZH,other.ZH):
             raise IOError("ZH arrays need to be identical (for now)")
         # Add em'
-        new = MetallicityPDF(self.ZH, self.pdf_ZH+other.pdf_ZH)
+        new = MetallicityPDF(self.ZH, self.pdf_ZH+other.pdf_ZH, normalize=False)
         # Return
         return new
 

--- a/pyigm/metallicity/tests/test_metal_pdf.py
+++ b/pyigm/metallicity/tests/test_metal_pdf.py
@@ -51,5 +51,6 @@ def test_add():
     mpdf2 = MetallicityPDF(ZH, pdf2)
     # Sum
     sum_pdf = mpdf + mpdf2
+    sum_pdf.normalize()
     # Test
     np.testing.assert_allclose(sum_pdf.meanZH,-1.5999356764972328)


### PR DESCRIPTION
Turned off normalization when adding MetallicityPDF objects.
A warning is thrown
