### PR TITLE
Handle cosmo differently in lyman_ew()

### DIFF
--- a/pyigm/fN/fnmodel.py
+++ b/pyigm/fN/fnmodel.py
@@ -5,6 +5,7 @@ from __future__ import print_function, absolute_import, division, unicode_litera
 import numpy as np
 import os, imp
 from scipy import interpolate as scii
+import warnings
 import pdb
 
 from astropy.io import fits
@@ -58,6 +59,12 @@ class FNModel(object):
         cosmo : astropy.cosmology, optional
           Cosmology for some calculations
         """
+        # Cosmology
+        if cosmo is None:
+            cosmo = cosmology.FlatLambdaCDM(H0=70, Om0=0.3) # Adopted in P14
+        else:
+            warnings.warn("Be careful here.  This fN model was derived with a specific cosmology.")
+
         if use_mcmc:
             from pyigm.fN import mcmc
             #raise ValueError("DEPRECATED")
@@ -69,7 +76,7 @@ class FNModel(object):
             # Build a model
             NHI_pivots = [12., 15., 17.0, 18.0, 20.0, 21., 21.5, 22.]
             fN_model = cls('Hspline', zmnx=(0.5,3.0),
-                            pivots=NHI_pivots,
+                            pivots=NHI_pivots, cosmo=cosmo,
                            param=dict(sply=np.array(outp['best_p'].flatten()))) # fN_data['FN']).flatten()))
                            #param=outp['best_p'])
         else:

--- a/pyigm/fN/tau_eff.py
+++ b/pyigm/fN/tau_eff.py
@@ -164,7 +164,10 @@ def lyman_ew(ilambda, zem, fN_model, NHI_MIN=11.5, NHI_MAX=22.0, N_eval=5000,
     """
     # Cosmology
     if cosmo is None:
-        cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
+        if fN_model.cosmo is not None:
+            cosmo = fN_model.cosmo
+        else:
+            cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
     # Lambda
     if not isinstance(ilambda, float):
         raise ValueError('tau_eff: ilambda must be a float for now')

--- a/pyigm/fN/tests/test_taueff.py
+++ b/pyigm/fN/tests/test_taueff.py
@@ -7,6 +7,7 @@ import copy
 import pytest
 
 import astropy.units as u
+from astropy.cosmology import FlatLambdaCDM
 
 from pyigm.fN.fnmodel import FNModel
 from pyigm.fN import tau_eff as pyteff
@@ -50,6 +51,11 @@ def test_lya():
     # Test
     #np.testing.assert_allclose(teff, 0.19821452949713764)
     np.testing.assert_allclose(teff, 0.1981831995528795)  # scipy 0.17
+    # Change cosmology
+    cosmo = FlatLambdaCDM(H0=60, Om0=0.2)
+    fN_model2 = FNModel.default_model(cosmo=cosmo)
+    teff2 = pyteff.lyman_ew(lamb, 2.5, fN_model2, NHI_MIN=12., NHI_MAX=17.)
+    np.testing.assert_allclose(teff2, 0.2379, rtol=1e-4)
 
 
 def test_lyx():


### PR DESCRIPTION
Makes use of the cosmo in fn_model (if set)
instead of simply defaulting to a vanilla cosmo.

New test too.