### PR TITLE
typo fix and rename in "densToLogU"

### DIFF
--- a/pyigm/metallicity/mcmc.py
+++ b/pyigm/metallicity/mcmc.py
@@ -108,7 +108,7 @@ from astropy import constants as const
 from scipy import integrate 
 from scipy.interpolate import interp1d
 
-def logUToDens(logU, redshift, UVB="HM05logU"):
+def logU_to_dens(logU, redshift, UVB="HM05logU"):
     """
     Convert logU to n_H (total H number density) using the given UVB.
     The only two UVBs for this are HM05 and HM12 because that's all I have packaged up.
@@ -174,7 +174,7 @@ def logUToDens(logU, redshift, UVB="HM05logU"):
     
 
 
-def densToLogU(dens, redshift, UVB='HM05logU'):
+def dens_to_logU(dens, redshift, UVB='HM05logU'):
     
     """
     This converts density (n_H) to logU.
@@ -212,7 +212,7 @@ def densToLogU(dens, redshift, UVB='HM05logU'):
     testDens = -999
     while abs(testDens - dens) > tolerance_dens:
         logU = logUarray[i]
-        testDens = logUToDens(logU, redshift, UVB=UVB)
+        testDens = logU_to_dens(logU, redshift, UVB=UVB)
         ##If it gets to this point, the tolerance has NOT been met
         
         ##If it's greater (i.e., positive), then
@@ -517,9 +517,9 @@ class Emceebones(object):
 
         ##calculate the density Gaussian based on the logU Gaussian
         ##NOTE: here we assume that it is symmetric
-        emc.densGaussMean=logUToDens(self.logUmean, self.info['z'], self.UVB)
-        # densGaussSigPos=logUToDens(logUmean+logUsigma, self.info['z'], self.UVB) - densGaussMean
-        # densGaussSigNeg=densGaussMean - logUToDens(logUmean-logUsigma, self.info['z'], self.UVB)
+        emc.densGaussMean=logU_to_dens(self.logUmean, self.info['z'], self.UVB)
+        # densGaussSigPos=logU_to_dens(logUmean+logUsigma, self.info['z'], self.UVB) - densGaussMean
+        # densGaussSigNeg=densGaussMean - logU_to_dens(logUmean-logUsigma, self.info['z'], self.UVB)
         # densGaussSig=max([densGaussSigPos,densGaussSigNeg])
         emc.densGaussSig=self.logUsigma
         ##CBW end

--- a/pyigm/metallicity/mcmc.py
+++ b/pyigm/metallicity/mcmc.py
@@ -174,7 +174,7 @@ def logUToDens(logU, redshift, UVB="HM05logU"):
     
 
 
-def densToLogU(dens, redshift, uvb='HM05logU'):
+def densToLogU(dens, redshift, UVB='HM05logU'):
     
     """
     This converts density (n_H) to logU.
@@ -212,7 +212,7 @@ def densToLogU(dens, redshift, uvb='HM05logU'):
     testDens = -999
     while abs(testDens - dens) > tolerance_dens:
         logU = logUarray[i]
-        testDens = logUToDens(logU, redshift, uvb=uvb)
+        testDens = logUToDens(logU, redshift, UVB=UVB)
         ##If it gets to this point, the tolerance has NOT been met
         
         ##If it's greater (i.e., positive), then

--- a/pyigm/metallicity/mcmc.py
+++ b/pyigm/metallicity/mcmc.py
@@ -174,7 +174,7 @@ def logUToDens(logU, redshift, UVB="HM05logU"):
     
 
 
-def dens2logu(dens, redshift, uvb='HM05logU'):
+def densToLogU(dens, redshift, uvb='HM05logU'):
     
     """
     This converts density (n_H) to logU.
@@ -212,7 +212,7 @@ def dens2logu(dens, redshift, uvb='HM05logU'):
     testDens = -999
     while abs(testDens - dens) > tolerance_dens:
         logU = logUarray[i]
-        testDens = logu2dens(logU, redshift, uvb=uvb)
+        testDens = logUToDens(logU, redshift, uvb=uvb)
         ##If it gets to this point, the tolerance has NOT been met
         
         ##If it's greater (i.e., positive), then


### PR DESCRIPTION
Renamed function from "dens2logu" to "densToLogU".  Also fixed a typo in that function: it had called "logu2dens" (which does not exist, because it had previously been renamed "logUToDens").