### PR TITLE
calc_rhoimpact: accept astropy Columns

### DIFF
--- a/pyigm/field/igmfield.py
+++ b/pyigm/field/igmfield.py
@@ -84,7 +84,8 @@ class IgmGalaxyField(object):
             los_coord = self.coord
         # Coord
         if ((isinstance(obj['RA'], Quantity)) |
-                (isinstance(obj['RA'],astropy.table.column.MaskedColumn))):
+                (isinstance(obj['RA'],astropy.table.column.MaskedColumn)) |
+                (isinstance(obj['RA'], astropy.table.column.Column))):
             ora = obj['RA']
             odec = obj['DEC']
         else:


### PR DESCRIPTION
Getting a bit kludgy, but method will not work with PHL1377 galaxy table without it.