### PR TITLE
Small changes to input file, and fix for Python2

### DIFF
--- a/docs/LLS_Metallicities-Wotta/queue_script.sh
+++ b/docs/LLS_Metallicities-Wotta/queue_script.sh
@@ -49,7 +49,7 @@ source "${pyvenv_loc}"/bin/activate
 pyigm_mtlmcmc_loc=()
 while IFS='' read -r -u"$FD" -d $'\0' file; do
     pyigm_mtlmcmc_loc+=("$file")
-done {FD}< <(find "${pyvenv_loc}" -name "pyigm_mtlmcmc.py" -print0)
+done {FD}< <(find -L "${pyvenv_loc}" -name "pyigm_mtlmcmc.py" -print0)
 
 
 ##Use a job array to loop over the row number

--- a/pyigm/metallicity/mcmc.py
+++ b/pyigm/metallicity/mcmc.py
@@ -297,9 +297,16 @@ class Emceebones(object):
         """
         
         #load the model in a format that can be handled later on
-        fil=open(model,'br')
-        modl=pickle.load(fil)
-        fil.close()
+        try:
+            ##Python3
+            fil=open(model,'br')
+            modl=pickle.load(fil)
+            fil.close()
+        except:
+            ##Python2
+            fil=open(model,'r')
+            modl=pickle.load(fil)
+            fil.close()
     
         #unpack axis tag, axis value, grid column, grid ions
         self.mod_axistag=modl[0]

--- a/pyigm/scripts/pyigm_mtlmcmc.py
+++ b/pyigm/scripts/pyigm_mtlmcmc.py
@@ -139,13 +139,17 @@ def run_mcmc_wotta(args):
     args.fileinput=input_file_dir+"/mcmc."+sightline+".in"        
 
     ##Grid file
-    ##Test whether to include the carbalpha parameter
+    ##Test whether to include the carbalpha parameter, and use the correct UVB
+    ##...But set a default first
+    if not args.grid:
+        args.grid = 'grid_minimal'
+    
     if str(carbalpha_use).lower() == 'false':
         ##Do NOT use the carbalpha parameter
-        args.grid = os.getcwd()+'/../Cloudy_grids_'+args.UVB+'/grid_minimal.pkl'
+        args.grid = os.getcwd()+'/../Cloudy_grids_'+args.UVB+'/'+args.grid+'.pkl'
     else:
         ##Use the carbalpha parameter
-        args.grid = os.getcwd()+'/../Cloudy_grids_'+args.UVB+'/grid_minimal_carbalpha.pkl'
+        args.grid = os.getcwd()+'/../Cloudy_grids_'+args.UVB+'/'+args.grid+'_carbalpha.pkl'
 
 
 
@@ -261,7 +265,7 @@ def main(args=None):
     parser.add_argument('-sightline', type=str, help='Name of the System to analyze')
     parser.add_argument('-fileinput')
     parser.add_argument('-outsave')
-    parser.add_argument('-grid')
+    parser.add_argument('-grid', type=str, help='Which Cloudy grid to use. If using with -carbalpha (i.e., --wotta), only give the stub (grid_minimal) not (grid_minimal_carbalpha).')
     parser.add_argument('-logUconstraint', type=str, help='Should we use logU constraint on density')
     parser.add_argument('-logUmean', type=str, help='If we use logUconstraint, what is the mean for the Gaussian?')
     parser.add_argument('-logUsigma', type=str, help='If we use logUconstraint, what is the sigma for the Gaussian?')


### PR DESCRIPTION
M.Fumagalli changed from `fil=open(model,'r')` to `fil=open(model,'br')` for use with Python3.  But this breaks in Python2.  So now we do a try/except.

Allowed --wotta option to accept -grid="x" option.

Fixed example queue_script.sh, so command can follow symlinks.