### PR TITLE
Pulled UVB integration out; Python3 fix

### DIFF
--- a/docs/LLS_Metallicities-Wotta/queue_script.sh
+++ b/docs/LLS_Metallicities-Wotta/queue_script.sh
@@ -15,7 +15,7 @@
 basename "$0"
 ##Prints date+time to STDOUT
 ##  (to get an idea for how long this took to run)
-date
+date '+%Y-%m-%d %H:%M:%S'
 ##Flush open file buffers every 300 sec (5 min) so
 ##  you can see any STDOUT BEFORE the job is completed
 fsync -d 300 $SGE_STDOUT_PATH &
@@ -78,7 +78,7 @@ deactivate
 
 ##Prints date+time to STDOUT
 ##  (to get an idea for how long this took to run)
-date
+date '+%Y-%m-%d %H:%M:%S'
 
 
 
@@ -100,14 +100,14 @@ date
 ##                               NOTE: This can be overridden by -logUconstraint option!
 ## -logUsigma=__       type=str, If we use logUconstraint, what is the sigma for the Gaussian?
 ##                               NOTE: This can be overridden by -logUconstraint option!
-## -UVB=__             type=str, The UVB to use when we are using the logU constraint on density (auto-detected if using --wotta)
+## -UVB=__             type=str, The UVB to use when we are using the logU constraint on density; (auto-detected if using --wotta)
 ## -nthread=__         type=int, Number of threads
 ## -nwalkers=__        type=int, Number of walkers
 ## -nsamp=__           type=int, Number of samples/steps
 ## -optim=__           type=str, Optimization method
-## -dens=__            type=float, Guess at density (optim=guess) (auto-detected if using --wotta)
-## -met=__             type=float, Guess at metallicity (optim=guess) (auto-detected if using --wotta)
-## -carbalpha=__       type=float, Guess at carbalpha (optim=guess) (auto-detected if using --wotta)
+## -dens=__            type=float, Guess at density (optim=guess); if "False", then optim=False; (auto-detected if using --wotta)
+## -met=__             type=float, Guess at metallicity (optim=guess); if "False", then optim=False; (auto-detected if using --wotta)
+## -carbalpha=__       type=float, Guess at carbalpha; if "True", uses carbalpha grid; if "False", does not use carbalpha grid; (auto-detected if using --wotta)
 ## --testing           If used, will over-ride minimum nwalkers and minimum nsamp
 ## --wotta             If used, reads in files using Wotta's file format (there is a guesses file,
 ##                     and each sightline has separate input file). If specified, the guesses file contains: dummy column at the front (not used here);

--- a/pyigm/metallicity/mcmc.py
+++ b/pyigm/metallicity/mcmc.py
@@ -166,7 +166,7 @@ def integrate_uvb(redshift, UVB="HM05logU"):
 
 
 
-def logU_to_dens(logU, redshift, spectrum=None, UVB="HM05logU"):
+def logU_to_dens(logU, redshift, UVB="HM05logU", spectrum=None):
     """
     Convert logU to n_H (total H number density) using the given UVB.
     The only two UVBs for this are HM05 and HM12 because that's all I have packaged up.
@@ -204,7 +204,7 @@ def logU_to_dens(logU, redshift, spectrum=None, UVB="HM05logU"):
     
 
 
-def dens_to_logU(dens, redshift, spectrum=None, UVB='HM05logU'):
+def dens_to_logU(dens, redshift, UVB='HM05logU', spectrum=None):
     
     """
     This converts density (n_H) to logU.
@@ -606,9 +606,9 @@ class Emceebones(object):
 
         ##calculate the density Gaussian based on the logU Gaussian
         ##NOTE: here we assume that it is symmetric
-        emc.densGaussMean=logU_to_dens(self.logUmean, self.info['z'], self.UVB)
-        # densGaussSigPos=logU_to_dens(logUmean+logUsigma, self.info['z'], self.UVB) - densGaussMean
-        # densGaussSigNeg=densGaussMean - logU_to_dens(logUmean-logUsigma, self.info['z'], self.UVB)
+        emc.densGaussMean=logU_to_dens(self.logUmean, self.info['z'], UVB=self.UVB)
+        # densGaussSigPos=logU_to_dens(logUmean+logUsigma, self.info['z'], UVB=self.UVB) - densGaussMean
+        # densGaussSigNeg=densGaussMean - logU_to_dens(logUmean-logUsigma, self.info['z'], UVB=self.UVB)
         # densGaussSig=max([densGaussSigPos,densGaussSigNeg])
         emc.densGaussSig=self.logUsigma
         ##CBW end

--- a/pyigm/scripts/pyigm_mtlmcmc.py
+++ b/pyigm/scripts/pyigm_mtlmcmc.py
@@ -21,7 +21,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-import pdb
 import numpy as np
 import sys
 import os
@@ -49,16 +48,16 @@ def read_guesses_file(guesses_file, row_index_to_run):
           'comment_out',
           'notes_in')
     
-    fmts=('str',
-        'str',
-        'float',
-        'float',
-        'float',
-        'str',
-        'str',
-        'str',
-        'str',
-        'str',
+    fmts=(str,
+        str,
+        float,
+        float,
+        float,
+        str,
+        str,
+        str,
+        str,
+        str,
         )
     
     input_dict={}
@@ -76,10 +75,10 @@ def read_guesses_file(guesses_file, row_index_to_run):
             linespl = line.strip().split()
             # linespl = [i.strip() for i in line.strip().split('|')]
             ##
-            for ls in xrange(len(linespl)):
-                if fmts[ls] == 'float':
-                    input_dict[keys[ls]].append(float(linespl[ls]))
-                else:
+            for ls in range(len(linespl)):
+                try:
+                    input_dict[keys[ls]].append(fmts[ls](linespl[ls]))
+                except:
                     input_dict[keys[ls]].append(linespl[ls])
     
     infile.close()
@@ -143,6 +142,13 @@ def run_mcmc_wotta(args):
         args.UVB, \
         comment_out, \
         notes], all_guesses = read_guesses_file(args.guessesfile, row_index)
+    
+    if (str(args.met).lower() == "false") or (str(args.dens).lower() == "false"):
+        ##The important one
+        args.optim=False
+        ##Set these just in case it makes a difference
+        args.met=False
+        args.dens=False
 
 
     ##Take care of logU guess

--- a/pyigm/scripts/pyigm_mtlmcmc.py
+++ b/pyigm/scripts/pyigm_mtlmcmc.py
@@ -32,7 +32,9 @@ from astropy.table import Table
 def read_guesses_file(guesses_file, row_index_to_run):
     """
     For use with --wotta, this reads the "input guesses" file
-    and sets "optim=guess" for the MCMC.
+    and sets "optim=guess" for the MCMC
+    ...unless met_guess_in == "False" or
+      dens_guess_in == "False" (see run_mcmc_wotta())
     """
     
     
@@ -328,9 +330,9 @@ def main(args=None):
     parser.add_argument('-nwalkers', type=int, help='Number of walkers')
     parser.add_argument('-nsamp', type=int, help='Number of samples')
     parser.add_argument('-optim', type=str, help='Optimization method')
-    parser.add_argument('-dens', type=float, help='Guess at density (optim=guess)')
-    parser.add_argument('-met', type=float, help='Guess at metallicity (optim=guess)')
-    parser.add_argument('-carbalpha', type=float, help='Guess at carbalpha (optim=guess)')
+    parser.add_argument('-dens', type=float, help='Guess at density (optim=guess); if "False", then optim=False')
+    parser.add_argument('-met', type=float, help='Guess at metallicity (optim=guess); if "False", then optim=False')
+    parser.add_argument('-carbalpha', type=float, help='Guess at carbalpha; if "True", uses carbalpha grid; if "False", does not use carbalpha grid')
     parser.add_argument("--testing", help="Set to test (over-rides minimum nwalkers)", action="store_true")
     parser.add_argument("--wotta", help="If used, reads in files using Wotta's file format (there is a guesses file, and each sightline has separate input file). If specified, the guesses file contains: dummy column at the front (not used here); the sightline name; metallicity initial guess; density initial guess; carbon/alpha ratio (carbalpha) initial guess (required, even if you don't want to use carbalpha); whether or not to allow carbalpha to vary; whether to use the Wotta+16 logUconstraint as a prior on the density; the UVB to use; ions to comment out (not used here);  and any additional notes (not used here). Then, all that needs to be specified here is: -guessesfile=__; -row=__ (in the guessesfile, usually automatically done by the supercomputer submission script); -nthread=__ (also done by the submission script); -nwalkers=__; and -nsamp=__.", action="store_true")
     parser.add_argument('-guessesfile')


### PR DESCRIPTION
Pulled function that integrates the UVB out of logU_to_dens converter function, allowing repeated called to logU_to_dens (or dens_to_logU) without reintegrating the spectrum every time.  Spectrum can now be passed as input to those converter functions.

Python 3 fix (xrange vs range)

"Initial guesses" file now allows the initial guesses to be False, if you'd like to set optim=True.  Useful for the first, quick, full-grid run for finding the maximum.  Then you'd follow up with an initial guess close to that maximum for a better result.  I was previously doing this, but it's much easier now.

Small documentation updates