### PR TITLE
Scrub unconstrained COS-Halos PDFs

### DIFF
--- a/pyigm/cgm/cos_halos.py
+++ b/pyigm/cgm/cos_halos.py
@@ -397,8 +397,16 @@ class COSHalos(CGMAbsSurvey):
         mkeys.remove('right_edge_bins')
         mkeys = np.array(mkeys)
 
+        def init_as_none(cga):
+            cga.igm_sys.metallicity = None
+            cga.igm_sys.NHIPDF = None
+            cga.igm_sys.density = None
+
         # Loop
         for cgm_abs in self.cgm_abs:
+            # Init
+            init_as_none(cgm_abs)
+            # Truncating
             if '0943+0531_227_19' in cgm_abs.name:
                 print('Not including 0943+0531_227_19'.format(cgm_abs.name))
                 print('See Prochaska+17 for details')
@@ -415,7 +423,16 @@ class COSHalos(CGMAbsSurvey):
                                          fh5['met'][mkeys[mt][0]])
             cgm_abs.igm_sys.metallicity.inputs = {}
             for key in fh5['inputs'][cgm_abs.name]:
+                # Warning the inputs here are goofy hdf5 bytes..
                 cgm_abs.igm_sys.metallicity.inputs[key] = fh5['inputs'][cgm_abs.name][key].value
+
+            # Check mtl quality
+            qual = mtl_quality(cgm_abs)
+            if qual <= 0:
+                # Back to None
+                init_as_none(cgm_abs)
+                continue
+
             # NHI
             cgm_abs.igm_sys.NHIPDF = GenericPDF(fh5['col']['left_edge_bins']+
                                                  fh5['col']['left_edge_bins'].attrs['BINSIZE']/2.,
@@ -901,3 +918,36 @@ class COSDwarfs(COSHalos):
             self.cgm_abs.append(cgmsys)
         tar.close()
 
+
+def mtl_quality(cgm_abs, verbose=True):
+    """ Assess the quality of the metallicity measurement for future analysis
+    Taken from the Patchup analysis
+
+    Parameters
+    ----------
+    cgmabs
+
+    Returns
+    -------
+    qual : int
+      -1 == No measurement at all
+      0  == Only limits to the ions
+      1  == Only one non-limit
+      #  == Two or more (number is the number)
+
+    """
+    try:
+        flgs = cgm_abs.igm_sys.metallicity.inputs['data'][:, 3].astype(int)
+    except IndexError:
+        if verbose:
+            print('No constraint for {:s}'.format(cgm_abs.name))
+            print('Skipping')
+        return -1
+    indices = np.where(flgs != -1)[0]
+    if len(indices) == 0:
+        if verbose:
+            print('No detection for {:s}'.format(cgm_abs.name))
+            print('Skipping')
+        return 0
+    else:
+        return len(indices)

--- a/pyigm/cgm/tests/test_coshalos.py
+++ b/pyigm/cgm/tests/test_coshalos.py
@@ -23,6 +23,20 @@ def test_load_kin():
     cos_halos.load_abskin()
 '''
 
+
+def test_PDF():
+    cos_halos = COSHalos()
+    cos_halos.load_mtl_pdfs()
+    all_NHI = []
+    all_mtl = []
+    for sl, sightline in enumerate(cos_halos.cgm_abs):
+        if sightline.igm_sys.NHIPDF is not None:
+            this_nhi = sightline.igm_sys.NHIPDF.median
+            all_NHI.append(this_nhi)
+            all_mtl.append(sightline.igm_sys.metallicity.median)
+    # Test
+    assert len(all_NHI) == 31
+
 def test_load_sngl():
     # Class
     cos_halos = COSHalos(fits_path=data_path(''), cdir=data_path(''), load=False)
@@ -55,9 +69,9 @@ def test_load_survey():
     assert len(cos_halos.cgm_abs) == 44
     # Metallicity
     cos_halos.load_mtl_pdfs()
-    # Confirm  J0943+0531_227_19 is out
+    # Confirm  J0943+0531_227_19 is out for metallicity
     cgm_j0943 = cos_halos[('J0943+0531','227_19')]
-    assert (not hasattr(cgm_j0943.igm_sys, 'metallicity'))
+    assert cgm_j0943.igm_sys.metallicity is None
 
 
 def test_getitem():


### PR DESCRIPTION
While we did generate a PDF for the metallicity of every 
COS-Halos sightline, this included ones with *no* metal ion
constraint (i.e. all upper limits).

I don't consider those trustworthy and these weren't analyzed
in the Patchups paper.  This PR sets all of those PDFs to None.

New test included.

Addresses Issue #180 