### PR TITLE
Pulled UVB integration to separate function

### DIFF
--- a/docs/LLS_Metallicities-Wotta/queue_script.sh
+++ b/docs/LLS_Metallicities-Wotta/queue_script.sh
@@ -15,7 +15,7 @@
 basename "$0"
 ##Prints date+time to STDOUT
 ##  (to get an idea for how long this took to run)
-date
+date '+%Y-%m-%d %H:%M:%S'
 ##Flush open file buffers every 300 sec (5 min) so
 ##  you can see any STDOUT BEFORE the job is completed
 fsync -d 300 $SGE_STDOUT_PATH &
@@ -78,7 +78,7 @@ deactivate
 
 ##Prints date+time to STDOUT
 ##  (to get an idea for how long this took to run)
-date
+date '+%Y-%m-%d %H:%M:%S'
 
 
 
@@ -100,14 +100,14 @@ date
 ##                               NOTE: This can be overridden by -logUconstraint option!
 ## -logUsigma=__       type=str, If we use logUconstraint, what is the sigma for the Gaussian?
 ##                               NOTE: This can be overridden by -logUconstraint option!
-## -UVB=__             type=str, The UVB to use when we are using the logU constraint on density (auto-detected if using --wotta)
+## -UVB=__             type=str, The UVB to use when we are using the logU constraint on density; (auto-detected if using --wotta)
 ## -nthread=__         type=int, Number of threads
 ## -nwalkers=__        type=int, Number of walkers
 ## -nsamp=__           type=int, Number of samples/steps
 ## -optim=__           type=str, Optimization method
-## -dens=__            type=float, Guess at density (optim=guess) (auto-detected if using --wotta)
-## -met=__             type=float, Guess at metallicity (optim=guess) (auto-detected if using --wotta)
-## -carbalpha=__       type=float, Guess at carbalpha (optim=guess) (auto-detected if using --wotta)
+## -dens=__            type=float, Guess at density (optim=guess); if "False", then optim=False; (auto-detected if using --wotta)
+## -met=__             type=float, Guess at metallicity (optim=guess); if "False", then optim=False; (auto-detected if using --wotta)
+## -carbalpha=__       type=float, Guess at carbalpha; if "True", uses carbalpha grid; if "False", does not use carbalpha grid; (auto-detected if using --wotta)
 ## --testing           If used, will over-ride minimum nwalkers and minimum nsamp
 ## --wotta             If used, reads in files using Wotta's file format (there is a guesses file,
 ##                     and each sightline has separate input file). If specified, the guesses file contains: dummy column at the front (not used here);

--- a/pyigm/metallicity/MCMC_output.py
+++ b/pyigm/metallicity/MCMC_output.py
@@ -233,7 +233,8 @@ class MCMC_output(object):
         if base_hist is not None:
             self.base_hist=base_hist
         else:
-            self.base_hist=np.arange(-3.6, 1.0001, self.binsize)
+            # self.base_hist=np.arange(-3.6, 1.0001, self.binsize)
+            self.base_hist=np.arange(-5.0, 2.5001, self.binsize)
         
         
         ############
@@ -629,17 +630,17 @@ class MCMC_output(object):
                     ci_low = 50 - (self.err_ci_limits/2.0)
                     ci_high = 50 + (self.err_ci_limits/2.0)
                 
-                temp_all_walkers = np.array(self.walkers)
+                temp_all_walkers = np.array(self.walkers[idx])
                 ##Need to check if we only have ONE walker axis, or if we
                 ##  have EVERYTHING (in which case we get a median for each axis)
                 if self.quantity:
-                    all_medians.append(np.median(temp_all_walkers[idx]))
-                    all_err_low.append(np.percentile(temp_all_walkers[idx],ci_low,axis=0))
-                    all_err_high.append(np.percentile(temp_all_walkers[idx],ci_high,axis=0))
+                    all_medians.append(np.median(temp_all_walkers))
+                    all_err_low.append(np.percentile(temp_all_walkers,ci_low,axis=0))
+                    all_err_high.append(np.percentile(temp_all_walkers,ci_high,axis=0))
                 else:
-                    all_medians.append([np.median(temp_all_walkers[idx][:,i]) for i in range(len(temp_all_walkers[idx][0]))])
-                    all_err_low.append([np.percentile(temp_all_walkers[idx][:,i],ci_low,axis=0) for i in range(len(temp_all_walkers[idx][0]))])
-                    all_err_high.append([np.percentile(temp_all_walkers[idx][:,i],ci_high,axis=0) for i in range(len(temp_all_walkers[idx][0]))])
+                    all_medians.append([np.median(temp_all_walkers[:,i]) for i in range(len(temp_all_walkers[0]))])
+                    all_err_low.append([np.percentile(temp_all_walkers[:,i],ci_low,axis=0) for i in range(len(temp_all_walkers[0]))])
+                    all_err_high.append([np.percentile(temp_all_walkers[:,i],ci_high,axis=0) for i in range(len(temp_all_walkers[0]))])
             
             ############
             ##Done looping over files
@@ -864,17 +865,38 @@ class MCMC_output(object):
         if self.nsys <= 0:
             self.limit_code = 999
         
-        hist, edges = np.histogram(self.walkers, bins=20)
-        max_height = hist.max()
-        
-        if hist[0] >= max_height*self.limit_threshold:
-            ##Upper limit
-            self.limit_code = -1
-        elif hist[-1] >= max_height*self.limit_threshold:
-            ##Lower limit
-            self.limit_code = -2
+        ##Need to check if we only want ONE walker axis (e.g., self.quantity == 'met'),
+        ##  or if we want to get EVERYTHING (i.e., self.quantity == None)
+        if self.quantity:
+            ##Then we have a single axis to get
+            hist, edges = np.histogram(self.walkers, bins=30)
+            max_height = hist.max()
+            
+            if hist[0] >= max_height*self.limit_threshold:
+                ##Upper limit
+                self.limit_code = -1
+            elif hist[-1] >= max_height*self.limit_threshold:
+                ##Lower limit
+                self.limit_code = -2
+            else:
+                self.limit_code = 0
         else:
-            self.limit_code = 0
+            temp_limit_code = []
+            for idx in range(len(self.walkers[0])):
+                ##Get all the walkers for THIS axis
+                hist, edges = np.histogram(self.walkers[:,idx], bins=30)
+                max_height = hist.max()
+                
+                if hist[0] >= max_height*self.limit_threshold:
+                    ##Upper limit
+                    temp_limit_code.append(-1)
+                elif hist[-1] >= max_height*self.limit_threshold:
+                    ##Lower limit
+                    temp_limit_code.append(-2)
+                else:
+                    temp_limit_code.append(0)
+                
+            self.limit_code = temp_limit_code
         
         # return self.limit_code
         return
@@ -892,9 +914,11 @@ class MCMC_output(object):
         ##  it's a list we want to loop over)
         infiles_is_list = False
         try:
+            ##Python2
             if not isinstance(self.infiles, basestring):
                 infiles_is_list = True
         except:
+            ##Python3
             if not isinstance(self.infiles, string_types):
                 infiles_is_list = True
         

--- a/pyigm/metallicity/MCMC_output.py
+++ b/pyigm/metallicity/MCMC_output.py
@@ -38,8 +38,9 @@ def NHI_defs():
     NHIdict['names']    = ['pLLS', 'LLS', 'SLLS', 'DLA']
     # NHIdict['names']    = ['pLLS', 'LLS', 'pLLS+LLS', 'SLLS', 'DLA']
     
-    NHIdict['diff CGM'] = [15.0, 16.0]
-    NHIdict['pLLS']     = [16.0, 17.2]
+    NHIdict['absorber'] = [15.0, 19.0]
+    NHIdict['SLFS']     = [15.0, 16.2]
+    NHIdict['pLLS']     = [16.2, 17.2]
     NHIdict['LLS']      = [17.2, 19.0]
     NHIdict['pLLS+LLS'] = [NHIdict['pLLS'][0], NHIdict['LLS'][1]]
     NHIdict['SLLS']     = [19.0, 20.3]
@@ -884,7 +885,7 @@ class MCMC_output(object):
             temp_limit_code = []
             for idx in range(len(self.walkers[0])):
                 ##Get all the walkers for THIS axis
-                hist, edges = np.histogram(self.walkers[:,idx], bins=30)
+                hist, edges = np.histogram(np.array(self.walkers)[:,idx], bins=30)
                 max_height = hist.max()
                 
                 if hist[0] >= max_height*self.limit_threshold:

--- a/pyigm/metallicity/mcmc.py
+++ b/pyigm/metallicity/mcmc.py
@@ -61,7 +61,7 @@ from __future__ import print_function, absolute_import, division, unicode_litera
 import matplotlib as mpl
 
 #The next line works on queue systems for DISPLAY issues
-#mpl.use('Agg')   #  Commented out by X to avoid test failures
+mpl.use('Agg')
 
 import warnings
 import pdb
@@ -108,25 +108,22 @@ from astropy import constants as const
 from scipy import integrate 
 from scipy.interpolate import interp1d
 
-def logU_to_dens(logU, redshift, UVB="HM05logU"):
+
+
+def integrate_uvb(redshift, UVB="HM05logU"):
     """
-    Convert logU to n_H (total H number density) using the given UVB.
+    Integrates the UVB spectrum, useful for computing logU.
     The only two UVBs for this are HM05 and HM12 because that's all I have packaged up.
     
     Parameters
     ----------
-    logU : float
-        The single value of logU that you wish to convert to density (n_H)
-    redshift : float
-        The redshift at which you'd like to convert logU --> density (n_H)
     UVB : str
         Which UVB to use. Currently, "HM05" and "HM12" are supported
     
     Returns
     ----------
-    dens : float
-        The single value of density (n_H) that corresponds to
-        the input logU and redshift, using the input UVB
+    phi,err : float np.array
+        The integrated UVB spectrum and corresponding error in the integration
     """
     ##This was taken almost directly from "getionisation.py" from Michele Fumagalli
     
@@ -165,6 +162,39 @@ def logU_to_dens(logU, redshift, UVB="HM05logU"):
     fint = interp1d(lognu,integrand)
     phi,err = integrate.quad(fint,ionnu,maxnu)
     
+    return phi,err
+
+
+
+def logU_to_dens(logU, redshift, UVB="HM05logU", spectrum=None):
+    """
+    Convert logU to n_H (total H number density) using the given UVB.
+    The only two UVBs for this are HM05 and HM12 because that's all I have packaged up.
+    
+    Parameters
+    ----------
+    logU : float
+        The single value of logU that you wish to convert to density (n_H)
+    redshift : float
+        The redshift at which you'd like to convert logU --> density (n_H)
+    spectrum : float np.array
+        The phi spectrum (from integrate_uvb). This way, we don't have to
+        re-integrate the spectrum EVERY time this function is called.
+    UVB : str
+        Which UVB to use. Currently, "HM05" and "HM12" are supported
+    
+    Returns
+    ----------
+    dens : float
+        The single value of density (n_H) that corresponds to
+        the input logU and redshift, using the input UVB
+    """
+    
+    if not spectrum:
+        phi,err = integrate_uvb(redshift, UVB)
+    else:
+        phi = spectrum
+    
     #now compute the ionization parameter
     # den=result['tags'].index('dens')
     # Uparam=np.log10(phi)-result['pdfs'][:,den]-np.log10(const.c.to('cm/s').value)
@@ -174,7 +204,7 @@ def logU_to_dens(logU, redshift, UVB="HM05logU"):
     
 
 
-def dens_to_logU(dens, redshift, UVB='HM05logU'):
+def dens_to_logU(dens, redshift, UVB='HM05logU', spectrum=None):
     
     """
     This converts density (n_H) to logU.
@@ -212,7 +242,7 @@ def dens_to_logU(dens, redshift, UVB='HM05logU'):
     testDens = -999
     while abs(testDens - dens) > tolerance_dens:
         logU = logUarray[i]
-        testDens = logU_to_dens(logU, redshift, UVB=UVB)
+        testDens = logU_to_dens(logU, redshift, spectrum=spectrum, UVB=UVB)
         ##If it gets to this point, the tolerance has NOT been met
         
         ##If it's greater (i.e., positive), then
@@ -224,7 +254,7 @@ def dens_to_logU(dens, redshift, UVB='HM05logU'):
         
         ##Go halfway between the highest "low" and
         ##  the lowest "high" i's
-        i = int(math.floor((high_i - low_i)/2. + low_i))
+        i = int(np.floor((high_i - low_i)/2. + low_i))
     
     
     return logU
@@ -446,8 +476,8 @@ class Emceebones(object):
         else:
             lutext = "False"
         
-        # plot_title = "{}\nUVB={}, log U prior={}".format(self.info['name'], self.UVB, lutext)
-        plot_title = "{}".format(self.info['name'])
+        plot_title = "{}\nUVB={}, log U prior={}".format(self.info['name'], self.UVB, lutext)
+        # plot_title = "{}".format(self.info['name'])
 
         
         ######
@@ -576,9 +606,9 @@ class Emceebones(object):
 
         ##calculate the density Gaussian based on the logU Gaussian
         ##NOTE: here we assume that it is symmetric
-        emc.densGaussMean=logU_to_dens(self.logUmean, self.info['z'], self.UVB)
-        # densGaussSigPos=logU_to_dens(logUmean+logUsigma, self.info['z'], self.UVB) - densGaussMean
-        # densGaussSigNeg=densGaussMean - logU_to_dens(logUmean-logUsigma, self.info['z'], self.UVB)
+        emc.densGaussMean=logU_to_dens(self.logUmean, self.info['z'], UVB=self.UVB)
+        # densGaussSigPos=logU_to_dens(logUmean+logUsigma, self.info['z'], UVB=self.UVB) - densGaussMean
+        # densGaussSigNeg=densGaussMean - logU_to_dens(logUmean-logUsigma, self.info['z'], UVB=self.UVB)
         # densGaussSig=max([densGaussSigPos,densGaussSigNeg])
         emc.densGaussSig=self.logUsigma
         ##CBW end

--- a/pyigm/metallicity/mcmc.py
+++ b/pyigm/metallicity/mcmc.py
@@ -61,7 +61,7 @@ from __future__ import print_function, absolute_import, division, unicode_litera
 import matplotlib as mpl
 
 #The next line works on queue systems for DISPLAY issues
-mpl.use('Agg')
+# mpl.use('Agg')    #  Commented out by X to avoid test failures
 
 import warnings
 import pdb


### PR DESCRIPTION
Biggest change: pull UVB integration out to separate function, so logU_to_dens() can be called repeatedly without re-integrating the spectrum each time.  Useful for converting a sightline's entire set of walkers from dens to logU.

Other changes: `--wotta` option now allows `optim=False`.  In `MCMC_initial_guesses-run_me.dat`, if either `met` or `dens` guess is set to False, `pyigm_mtlmcmc.py` will now set `optim=False` when sending to `mcmc.py`.

Minor changes: documentation