### PR TITLE
Igmsightline features

### DIFF
--- a/pyigm/fN/mockforest.py
+++ b/pyigm/fN/mockforest.py
@@ -88,9 +88,10 @@ def monte_HIcomp(zmnx, fN_model, NHI_mnx=(12., 22.), bfix=None, dz=0.001, cosmo=
             seed = 12345
         rstate = np.random.RandomState(seed)
 
+    ### Method handles powerlaws just fine also
     # Check fN_model type
-    if fN_model.fN_mtype != 'Hspline':
-        raise ValueError('monte_HIlines: Can only handle Hspline so far.')
+    #if fN_model.fN_mtype != 'Hspline':
+    #    raise ValueError('monte_HIlines: Can only handle Hspline so far.')
 
     # Calculate lX at pivot
     lX, cum_lX, lX_NHI = fN_model.calculate_lox(fN_model.zpivot,

--- a/pyigm/igm/igmsightline.py
+++ b/pyigm/igm/igmsightline.py
@@ -151,8 +151,12 @@ class IGMSightline(AbsSightline):
         if 'cmps' in idict.keys():
             idict['components'] = idict['cmps'].copy()
         # Instantiate
-        slf = cls(SkyCoord(ra=meta['RA'], dec=meta['DEC'], unit='deg'),
+        try:
+            slf = cls(SkyCoord(ra=meta['RA'], dec=meta['DEC'], unit='deg'),
                   zem=meta['zem'], name=meta['JNAME'], **kwargs)
+        except KeyError:
+            slf = cls(SkyCoord(ra=meta['RA'], dec=meta['DEC'], unit='deg'),
+                      zem=meta['zem'], name=meta['name'], **kwargs)
         # Other
         for key in idict.keys():
             if key in ['RA', 'DEC', 'zem', 'name', 'components', 'meta', 'cmps']:

--- a/pyigm/igm/igmsightline.py
+++ b/pyigm/igm/igmsightline.py
@@ -40,7 +40,8 @@ class IGMSightline(AbsSightline):
         return slf
 
     @classmethod
-    def from_igmguesses(cls, igmgfile, name=None, radec=None, zem=None, **kwargs):
+    def from_igmguesses(cls, igmgfile, name=None, radec=None, zem=None,
+                        buildsys = False, **kwargs):
         """ Instantiate from a JSON file from IGMGuesses
 
         Parameters
@@ -55,6 +56,8 @@ class IGMSightline(AbsSightline):
         zem : float, optional
           Emission redshift of sightline
           If given, it will overwrite the zem in IGMGuesses file (if any)
+        buildsys : bool, optional
+          If True, instantiate AbsSystem objects
 
         Returns
         -------
@@ -114,6 +117,9 @@ class IGMSightline(AbsSightline):
         for key in ['spec_file', 'meta', 'fwhm']:
             slf.igmg_dict[key] = jdict[key]
         # Return
+
+        if buildsys:
+            slf.make_igmsystems()
         return slf
 
     @classmethod
@@ -196,6 +202,7 @@ class IGMSightline(AbsSightline):
         # Main call
         igm_sys = build_systems_from_components(self._components, systype=igmsystem, **kwargs)
         # Return
+        self._abssystems = igm_sys
         return igm_sys
 
     def write_to_json(self, outfile):


### PR DESCRIPTION
Fixes to mockforest routines for accepting powerlaw CDDFs.  Unrelated, added option to instantiate abssystems upon creating IGMsightilnes from igmguesses output.  Also, IGMSightline.make_igmsystems() now adds those systems to igmsightline._abssystems.