### PR TITLE
Adding utility function is_not_HILya()

### DIFF
--- a/pyigm/guis/igmguesses.py
+++ b/pyigm/guis/igmguesses.py
@@ -2114,7 +2114,7 @@ def from_igmguesses_to_complist(infile):
         # import pdb; pdb.set_trace()
         idict = igmg_dict['cmps'][key]
         try:
-            comp = AbsComponent.from_dict(idict, skip_abslines=False, chk_sep=False, chk_data=False, chk_vel=False, linelist="ISM")
+            comp = AbsComponent.from_dict(idict, skip_abslines=False, chk_sep=False, chk_data=False, chk_vel=False, linelist=LineList('ISM'))
         except ValueError:  # if ion species not in LineList ISM
             print("Warning: Transition not in the ISM LineList. Will try others...")
             comp = None

--- a/pyigm/guis/igmguesses.py
+++ b/pyigm/guis/igmguesses.py
@@ -2102,6 +2102,7 @@ def from_igmguesses_to_complist(infile):
 
     """
     import json
+    ism = LineList('ISM')
     # Read the JSON file
     with open(infile) as data_file:
         igmg_dict = json.load(data_file)
@@ -2114,7 +2115,7 @@ def from_igmguesses_to_complist(infile):
         # import pdb; pdb.set_trace()
         idict = igmg_dict['cmps'][key]
         try:
-            comp = AbsComponent.from_dict(idict, skip_abslines=False, chk_sep=False, chk_data=False, chk_vel=False, linelist=LineList('ISM'))
+            comp = AbsComponent.from_dict(idict, skip_abslines=False, chk_sep=False, chk_data=False, chk_vel=False, linelist=ism)
         except ValueError:  # if ion species not in LineList ISM
             print("Warning: Transition not in the ISM LineList. Will try others...")
             comp = None

--- a/pyigm/surveys/utils.py
+++ b/pyigm/surveys/utils.py
@@ -7,6 +7,7 @@ import glob
 import json
 import pdb
 
+import numpy as np
 from astropy.coordinates import SkyCoord
 
 from linetools import utils as ltu

--- a/pyigm/surveys/utils.py
+++ b/pyigm/surveys/utils.py
@@ -128,15 +128,16 @@ def is_not_HILya(wvobs, comps):
 
     Parameters
     ----------
-    wobs : Quantity array
+    wvobs : Quantity array
         Observed wavelength
     comp : list of AbsComponent objects
         List of abscomponent objects identified
 
     Returns
     -------
-    answer : bool
-        True if there is a identified line that is not HI Lya, otherwise False
+    answer : boolean array
+        Same shape as `wvobs`. True if there is a identified line  that is not HI Lya at
+        the corresponding wavelength, otherwise False
 
     """
 

--- a/pyigm/surveys/utils.py
+++ b/pyigm/surveys/utils.py
@@ -119,3 +119,33 @@ def class_by_type(type):
     # Return
     return survey
 
+
+def is_not_HILya(wvobs, comps):
+    """Given an array of wavelengths, this function returns a boolean array of same shape as
+    `wvobs` with True for pixels known to be contaminated by non HI Lya absorption given a list
+    of AbsComponent objects
+
+    Parameters
+    ----------
+    wobs : Quantity array
+        Observed wavelength
+    comp : list of AbsComponent objects
+        List of abscomponent objects identified
+
+    Returns
+    -------
+    answer : bool
+        True if there is a identified line that is not HI Lya, otherwise False
+
+    """
+
+    # loop over component and abslines
+    cond = False * len(wvobs)
+    for comp in comps:
+        for line in comp._abslines:
+            if line.name != 'HI 1215':
+                wvlims = line.limits.wvlim
+                cond_aux = (wvobs >= wvlims[0]) & (wvobs <= wvlims[1])
+                cond = cond_aux | cond
+    return np.array(cond).astype(bool)
+


### PR DESCRIPTION
As stated. A simple function that identifies pixels that belong to a metal line or a higher-order HI Lyman absorption from an input wavelength array. Useful for masking out interlopers.