### PR TITLE
Adding an option to igmguesses to calculate transitions over a wider wavelength range than the input spectrum

### DIFF
--- a/pyigm/guis/igmguesses.py
+++ b/pyigm/guis/igmguesses.py
@@ -111,6 +111,12 @@ class IGMGuessesGui(QMainWindow):
             Minimum and maximum velocity limit for the display; e.g. [-500.,500.]*u.km/u.s
         external_model : str
             Name of an external model to load.
+        redsh : float, optional
+            Redshift at which transitions are initially plotted
+        spwvmin : float, optional
+            Minimum wavelength for which line transitions are calculated
+        spwvmax : float, optional
+            Maximum wavelength for which line transitions are calculated
 
         """
         # TODO

--- a/pyigm/guis/igmguesses.py
+++ b/pyigm/guis/igmguesses.py
@@ -766,13 +766,11 @@ class IGGVelPlotWidget(QWidget):
             self.model.flux[:] = 1.
             return
         # Setup lines
-        wvmin, wvmax = np.min(self.spec.wavelength), np.max(self.spec.wavelength)
+        #wvmin, wvmax = np.min(self.spec.wavelength), np.max(self.spec.wavelength)
         spwvmin = self.parent.wvmin
         spwvmax = self.parent.wvmax
-        if spwvmin is not None:
-            wvmin = spwvmin
-        if spwvmax is not None:
-            wvmax = spwvmax
+        wvmin = spwvmin
+        wvmax = spwvmax
 
         gdlin = []
         for comp in all_comp:
@@ -1901,7 +1899,7 @@ def create_component(z, wrest, linelist, vlim=[-300.,300]*u.km/u.s,
 
 def comp_init_attrib(comp):
     # Attributes
-    comp.attrib = {'N': 0./u.cm**2, 'Nsig': 0./u.cm**2, 'flag_N': 0,  # Column
+    comp.attrib = {'N': 0./u.cm**2, 'Nsig': 0./u.cm**2, 'flagN': 0,  # Column
                'logN': 0., 'sig_logN': 0.,
                'b': 0.*u.km/u.s, 'bsig': 0.*u.km/u.s,  # Doppler
                'z': comp.zcomp, 'zsig': 0.,

--- a/pyigm/guis/igmguesses.py
+++ b/pyigm/guis/igmguesses.py
@@ -86,7 +86,7 @@ class IGMGuessesGui(QMainWindow):
         srch_id=True, outfil=None, fwhm=None, screen_scale=1.,
         plot_residuals=True,n_max_tuple=None, min_strength=None,
                  min_ew=None, vlim_disp=None, external_model=None, redsh=None,
-                 spwvmin=None,spwvmax=None): #added redsh=None
+                 spwvmin=None,spwvmax=None):
         QMainWindow.__init__(self, parent)
         """
         ispec : str
@@ -207,9 +207,6 @@ E         : toggle displaying/hiding the external absorption model
             vlim_disp = [-500.,500.] * u.km/u.s
         self.vlim_disp = vlim_disp
 
-        #####################
-        #self.wvmin = 1383. *u.AA
-        #self.wvmax = 3691. *u.AA
 
 
         # Load spectrum
@@ -220,7 +217,6 @@ E         : toggle displaying/hiding the external absorption model
             self.wvmin = spwvmin *u.AA
         else:
             self.wvmin = np.min(spec.wavelength)
-        #
         if spwvmax is not None:
             self.wvmax = spwvmax *u.AA
         else:
@@ -481,7 +477,6 @@ E         : toggle displaying/hiding the external absorption model
                 # QtCore.pyqtRemoveInputHook()
                 # pdb.set_trace()
                 # QtCore.pyqtRestoreInputHook()
-                #pdb.set_trace()
                 comp_init_attrib(comp)
                 comp.init_wrest = igmg_dict['cmps'][key]['wrest']*u.AA
                 try:
@@ -489,7 +484,6 @@ E         : toggle displaying/hiding the external absorption model
                 except KeyError:  # For compatibility
                     warnings.warn("Setting all abslines to 2")
                     comp.mask_abslines = 2*np.ones(len(comp._abslines)).astype(int)
-                #pdb.set_trace()
                 self.velplot_widg.add_component(comp, update_model=False)
 
             else:  # for compatibility, should be deprecated
@@ -758,7 +752,7 @@ class IGGVelPlotWidget(QWidget):
 
 
     # Update model
-    def update_model(self): #,spwvmin=None,spwvmax=None):
+    def update_model(self):
         if self.parent is None:
             return
         all_comp = self.parent.comps_widg.all_comp # selected_components()
@@ -774,7 +768,6 @@ class IGGVelPlotWidget(QWidget):
         if spwvmax is not None:
             wvmax = spwvmax
 
-        #wvmin, wvmax = spwvmin, spwvmax # self.wvmin, self.wvmax # test
         gdlin = []
         for comp in all_comp:
             for ii, line in enumerate(comp._abslines):
@@ -812,30 +805,23 @@ class IGGVelPlotWidget(QWidget):
         """
         # this is mostly from reading previous IGM_model
 
-        #pdb.set_trace()
-
         if isinstance(inp, AbsComponent):
-
-            #pdb.set_trace()
 
             # get rid of lines outside spectral coverage, if any
             # Todo: one may want to reconsider this, specially if more spectral coverage is obtained
             new_abslines = []
             for absline in inp._abslines:
                 wobs = absline.wrest * (1 + absline.z)
-                #if (wobs > self.spec.wvmin) and (wobs < self.spec.wvmax): # commented for the test below
-                #pdb.set_trace()
-                if (wobs > self.parent.wvmin) and (wobs < self.parent.wvmax): # test # self.spwvmnx
+                if (wobs > self.parent.wvmin) and (wobs < self.parent.wvmax):
                     new_abslines += [absline]
 
             if len(new_abslines) == 0:
-                self.current_comp = None ####
+                self.current_comp = None
                 return
 
             inp._abslines = new_abslines
             new_comp = inp
 
-            #pdb.set_trace()
 
             # compatibility with older versions
             try:
@@ -958,8 +944,6 @@ class IGGVelPlotWidget(QWidget):
         '''Check for out of bounds
         '''
         # Default is x
-        #if ((coord < np.min(self.spec.wavelength))
-        #    or (coord > np.max(self.spec.wavelength))):
         if ((coord < self.parent.wvmin)
             or (coord > self.parent.wvmax)):
             print('Out of bounds!')
@@ -1852,7 +1836,6 @@ def create_component(z, wrest, linelist, vlim=[-300.,300]*u.km/u.s,
     abslines = []
     if spec is not None:
         wvmin, wvmax = spec.wvmin, spec.wvmax
-        #wvmin, wvmax = 1383.*u.AA, 3691.*u.AA
         if spwvmin is not None:
             wvmin = spwvmin
         if spwvmax is not None:

--- a/pyigm/scripts/pyigm_igmguesses.py
+++ b/pyigm/scripts/pyigm_igmguesses.py
@@ -38,9 +38,9 @@ def parser(options=None):
     parser.add_argument("--vlim", type=float, help="Velocity limit (in km/s) for the display. This limit will apply to both sides")
     parser.add_argument("--external_model", type=str, help="An external model spectrum (.fits)")
     parser.add_argument("--scale", type=float, help="Scaling of screen [default=1.]")
-    parser.add_argument("-redsh","--redsh",type=float,help="Redshift") # added line
-    parser.add_argument("-wmin", "--wmin", type=float, help="Wmin")  # added line
-    parser.add_argument("-wmax", "--wmax", type=float, help="Wmax")  # added line
+    parser.add_argument("-redsh","--redsh",type=float,help="Redshift")
+    parser.add_argument("-wmin", "--wmin", type=float, help="Wmin")
+    parser.add_argument("-wmax", "--wmax", type=float, help="Wmax")
 
     if options is None:
         args = parser.parse_args()
@@ -79,7 +79,6 @@ def main(args=None):
                         external_model=pargs.external_model,
                         redsh=pargs.redsh,
                         spwvmin=pargs.wmin, spwvmax=pargs.wmax)
-                        # spwvmin=None, spwvmax=None)
     gui.show()
     app.exec_()
 

--- a/pyigm/scripts/pyigm_igmguesses.py
+++ b/pyigm/scripts/pyigm_igmguesses.py
@@ -38,9 +38,9 @@ def parser(options=None):
     parser.add_argument("--vlim", type=float, help="Velocity limit (in km/s) for the display. This limit will apply to both sides")
     parser.add_argument("--external_model", type=str, help="An external model spectrum (.fits)")
     parser.add_argument("--scale", type=float, help="Scaling of screen [default=1.]")
-    parser.add_argument("-redsh","--redsh",type=float,help="Redshift")
-    parser.add_argument("-wmin", "--wmin", type=float, help="Wmin")
-    parser.add_argument("-wmax", "--wmax", type=float, help="Wmax")
+    parser.add_argument("-redsh","--redsh",type=float,help="Redshift at which transitions are initially plotted")
+    parser.add_argument("-wmin", "--wmin", type=float, help="Minimum wavelenght for which line transitions are calculated")
+    parser.add_argument("-wmax", "--wmax", type=float, help="Maximum wavelenght for which line transitions are calculated")
 
     if options is None:
         args = parser.parse_args()

--- a/pyigm/scripts/pyigm_igmguesses.py
+++ b/pyigm/scripts/pyigm_igmguesses.py
@@ -39,6 +39,8 @@ def parser(options=None):
     parser.add_argument("--external_model", type=str, help="An external model spectrum (.fits)")
     parser.add_argument("--scale", type=float, help="Scaling of screen [default=1.]")
     parser.add_argument("-redsh","--redsh",type=float,help="Redshift") # added line
+    parser.add_argument("-wmin", "--wmin", type=float, help="Wmin")  # added line
+    parser.add_argument("-wmax", "--wmax", type=float, help="Wmax")  # added line
 
     if options is None:
         args = parser.parse_args()
@@ -75,7 +77,9 @@ def main(args=None):
                         screen_scale=scale,
                         vlim_disp=vlim_disp,
                         external_model=pargs.external_model,
-                        redsh=pargs.redsh)
+                        redsh=pargs.redsh,
+                        spwvmin=pargs.wmin, spwvmax=pargs.wmax)
+                        # spwvmin=None, spwvmax=None)
     gui.show()
     app.exec_()
 


### PR DESCRIPTION
In this way, two spectra of the same object with different wavelength range could share the same .json igmguesses output file and transitions in that file. 